### PR TITLE
Add an .editorconfig to ensure consistent whitespace policy

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig  http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# All files
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
`src/README.md already` says:

> _Before_ beginning development, especially on teams, make sure to configure your linter and code formatting to conform to one unified setting

EditorConfig (see https://editorconfig.org/) is a fantastic way to ensure that many editors will automatically configure themselves with settings to correctly match any project containing an .editorconfig file.  So add one to this project with settings matching the existing style (including 2-column indentation).