### PR TITLE
Handle undefined currLocation in MainSlider

### DIFF
--- a/src/app/components/MainSlider.tsx
+++ b/src/app/components/MainSlider.tsx
@@ -42,7 +42,9 @@ function MainSlider(props: MainSliderProps) {
   const [sliderIndex, setSliderIndex] = useState(0);
 
   useEffect(() => {
-    setSliderIndex(currLocation.index);
+    if (currLocation) {
+      setSliderIndex(currLocation.index);
+    }
   }, [currLocation])
 
   return (


### PR DESCRIPTION
Sometimes the `currLocation` is uninitialised which can cause a crash, so handle that case gracefully by adding a check.