### PR TITLE
Fix validateDOMNesting errors within <p> of <Hover>

### DIFF
--- a/src/app/components/Action.tsx
+++ b/src/app/components/Action.tsx
@@ -150,7 +150,7 @@ const Action = (props: ActionProps): JSX.Element => {
         </Trigger>
         <Hover type="hover">
           <div style={{ zIndex: 1, position: 'relative', padding: '0.5rem 1rem' }} id="hover-box">
-            <p>{(logChangedState(index))}</p>
+            {(logChangedState(index))}
           </div>
         </Hover>
       </ReactHover>


### PR DESCRIPTION
The `<Hover>` element under `<Action>` tries to nest `<pre>` and `<div>` under `<p>`, leading to errors such as:

    react-dom.development.js:88 Warning: validateDOMNesting(...): <pre> cannot appear as a descendant of <p>.
        in pre (created by Action)
        in div (created by Action)
        in div (created by Action)
        in p (created by Action)
        in div (created by Action)
        in div (created by Hover)
        in Hover (created by ReactHover)
        in div (created by ReactHover)
        in ReactHover (created by Action)
        in div (created by Action)
        in Action (created by ActionContainer)
        in div (created by ActionContainer)
        in div (created by ActionContainer)
        in div (created by ActionContainer)
        in ActionContainer (created by MainContainer)
        in div (created by MainContainer)
        in div (created by MainContainer)
        in MainContainer (created by App)
        in App

So remove the `<p>` wrapping to fix these errors.