### PR TITLE
Add missing key attribute for <option> list in nodeOptions datalist

### DIFF
--- a/src/app/components/LinkControls.tsx
+++ b/src/app/components/LinkControls.tsx
@@ -118,7 +118,7 @@ export default function LinkControls({
       />
       <datalist id='nodeOptions'>
         {nodeList.map(node => (
-          <option value={node.name}>{node.name}</option>
+          <option value={node.name} key={node.name}>{node.name}</option>
         ))}
       </datalist>
 


### PR DESCRIPTION
The `Select` dropdown in the Map view provides a list of nodes to select, but React requires that every element of a list has a `key`
attribute to enable its DOM tracking / reconciliation.

So add the missing `key` attribute to avoid this warning:

    react.development.js:315 Warning: Each child in a list should have a unique "key" prop.