### PR TITLE
Fix z attribute of <text> in <ComponentMap>

### DIFF
--- a/src/app/components/ComponentMap.tsx
+++ b/src/app/components/ComponentMap.tsx
@@ -367,7 +367,7 @@ export default function ComponentMap({
                               ? 'white'
                               : '#161521'
                         }
-                        z
+                        z={1}
                       >
                         {node.data.name}
                       </text>


### PR DESCRIPTION
A `z` attribute without a corresponding value triggers the following error:

```
Warning: Received `true` for a non-boolean attribute `z`.

    If you want to write it to the DOM, pass a string instead: z="true" or z={value.toString()}.
        in text (created by Tree)
        in g (created by Group)
        in Group (created by Tree)
        in g (created by Group)
        in Group (created by Tree)
        in Tree (created by ComponentMap)
        in g (created by Group)
        in Group (created by ComponentMap)
        in svg (created by ComponentMap)
        in div (created by ComponentMap)
        in ComponentMap (created by ParentSize)
        in div (created by ParentSize)
        in ParentSize (created by Context.Consumer)
        in Route (created by StateRoute)
        in Switch (created by StateRoute)
        in Router (created by MemoryRouter)
        in MemoryRouter (created by StateRoute)
        in StateRoute (created by Context.Consumer)
        in Route (created by StateContainer)
        in Switch (created by StateContainer)
        in div (created by StateContainer)
        in Router (created by MemoryRouter)
        in MemoryRouter (created by StateContainer)
        in StateContainer (created by MainContainer)
        in div (created by MainContainer)
        in div (created by MainContainer)
        in MainContainer (created by App)
        in App
```

So add a value to fix this warning.