### PR TITLE
Add missing key attribute for <p class="stateprops"> list in ComponentMap

### DIFF
--- a/src/app/components/ComponentMap.tsx
+++ b/src/app/components/ComponentMap.tsx
@@ -176,7 +176,7 @@ export default function ComponentMap({
     const nestedObj = [];
     for (const key in data) {
       if (data[key] !== 'reactFiber' && typeof data[key] !== 'object' && exclude.includes(key) !== true) {
-        propsFormat.push(<p className="stateprops">
+        propsFormat.push(<p className="stateprops" key={key}>
           {`${key}: ${data[key]}`}
         </p>);
       } else if (data[key] !== 'reactFiber' && typeof data[key] === 'object' && exclude.includes(key) !== true) {


### PR DESCRIPTION
In the ComponentMap view, the tooltip viewable after clicking on a component has a list of <p className="stateprops"> elements, but React requires that every element of a list has a `key` attribute to enable its DOM tracking / reconciliation.

So add the missing `key` attribute to avoid this warning:

    react.development.js:315 Warning: Each child in a list should have a unique "key" prop.