### PR TITLE
Change unsupported style property pointer-events to pointerEvents

### DIFF
--- a/src/app/components/ComponentMap.tsx
+++ b/src/app/components/ComponentMap.tsx
@@ -135,7 +135,7 @@ export default function ComponentMap({
     lineHeight: '18px',
     fontFamily: 'Roboto',
     zIndex: 100,
-    'pointer-events': 'all !important',
+    pointerEvents: 'all !important',
   };
 
   const scrollStyle = {


### PR DESCRIPTION
The ComponentMap was causing this error:

    react-dom.development.js:88 Warning: Unsupported style property pointer-events. Did you mean pointerEvents?
        in div (created by Tooltip)
        in Tooltip (created by TooltipWithBounds)
        in TooltipWithBounds (created by withBoundingRects())
        in withBoundingRects()
        in Portal
        in Unknown (created by ComponentMap)
        in div (created by ComponentMap)
        in ComponentMap (created by ParentSize)
        in div (created by ParentSize)
        in ParentSize (created by Context.Consumer)
        in Route (created by StateRoute)
        in Switch (created by StateRoute)
        in Router (created by MemoryRouter)
        in MemoryRouter (created by StateRoute)
        in StateRoute (created by Context.Consumer)
        in Route (created by StateContainer)
        in Switch (created by StateContainer)
        in div (created by StateContainer)
        in Router (created by MemoryRouter)
        in MemoryRouter (created by StateContainer)
        in StateContainer (created by MainContainer)
        in div (created by MainContainer)
        in div (created by MainContainer)
        in MainContainer (created by App)
        in App

so change it to pointerEvents.