### PR TITLE
feat: toast notifications for key session events (clear, export, import, disconnect)

### DIFF
--- a/src/app/containers/ActionContainer.tsx
+++ b/src/app/containers/ActionContainer.tsx
@@ -9,6 +9,8 @@ import ProvConContainer from './ProvConContainer';
 import { ActionContainerProps, CurrentTab, MainState, Obj, RootState } from '../FrontendTypes';
 import { Button } from '@mui/material';
 import RecordButton from '../components/Actions/RecordButton';
+import { toast } from 'react-hot-toast';
+import { REACTIME_TOAST_DEFAULTS } from '../utils/toastConfig';
 
 /*
   This file renders the 'ActionContainer'. The action container is the leftmost column in the application. It includes the button that shrinks and expands the action container, a dropdown to select the active site, a clear button, the current selected Route, and a list of selectable snapshots with timestamps.
@@ -163,9 +165,22 @@ function ActionContainer(props: ActionContainerProps): JSX.Element {
             className='clear-button-modern'
             variant='text'
             onClick={() => {
+              const clearedCount = snapshots?.length ?? 0;
               dispatch(emptySnapshots()); // set slider back to zero, visually
               dispatch(changeSlider(0));
               setExpandedIndex(null); // Reset expanded state when clearing
+              if (clearedCount > 0) {
+                toast.success(
+                  `Cleared ${clearedCount} snapshot${clearedCount === 1 ? '' : 's'}`,
+                  { ...REACTIME_TOAST_DEFAULTS, id: 'snapshots-cleared' },
+                );
+              } else {
+                toast('No snapshots to clear', {
+                  ...REACTIME_TOAST_DEFAULTS,
+                  id: 'snapshots-cleared',
+                  icon: 'ℹ️',
+                });
+              }
             }}
             type='button'
           >

--- a/src/app/containers/ButtonsContainer.tsx
+++ b/src/app/containers/ButtonsContainer.tsx
@@ -7,33 +7,112 @@ import StatusDot from '../components/Buttons/StatusDot';
 import { MainState, RootState } from '../FrontendTypes';
 import { Lock, Unlock, Download, Upload, RefreshCw } from 'lucide-react';
 import { toast } from 'react-hot-toast';
+import { REACTIME_TOAST_DEFAULTS } from '../utils/toastConfig';
+
+/**
+ * Builds a stable, human-readable filename for exported sessions so the
+ * toast can show users exactly what ended up in their Downloads folder
+ * (and so multiple exports don't silently overwrite each other).
+ */
+function buildExportFilename(): string {
+  const now = new Date();
+  const yyyy = now.getFullYear();
+  const mm = String(now.getMonth() + 1).padStart(2, '0');
+  const dd = String(now.getDate()).padStart(2, '0');
+  const hh = String(now.getHours()).padStart(2, '0');
+  const mi = String(now.getMinutes()).padStart(2, '0');
+  return `reactime-session-${yyyy}-${mm}-${dd}-${hh}${mi}.json`;
+}
 
 function exportHandler(snapshots: []): void {
+  const filename = buildExportFilename();
   const fileDownload: HTMLAnchorElement = document.createElement('a');
   fileDownload.href = URL.createObjectURL(
     new Blob([JSON.stringify(snapshots)], { type: 'application/json' }),
   );
-  fileDownload.setAttribute('download', 'snapshot.json');
+  fileDownload.setAttribute('download', filename);
   fileDownload.click();
   URL.revokeObjectURL(fileDownload.href);
+
+  // `snapshots` here is the current tab's state object (see call site passing
+  // tabs[currentTab]), not a tabs map. Its `.snapshots` field is the actual
+  // array used for time travel — that's the count the user cares about.
+  const tabData = snapshots as unknown as { snapshots?: unknown[] } | null | undefined;
+  const snapshotCount = Array.isArray(tabData?.snapshots) ? tabData.snapshots.length : 0;
+
+  toast.success(
+    snapshotCount > 0
+      ? `Exported ${snapshotCount} snapshot${snapshotCount === 1 ? '' : 's'} to ${filename}`
+      : `Exported session to ${filename}`,
+    { ...REACTIME_TOAST_DEFAULTS, duration: 3500, id: 'session-exported' },
+  );
+}
+
+/**
+ * Reads a file and resolves with the parsed snapshot payload, or rejects
+ * with a descriptive error. Split out so importHandler can wrap it with
+ * toast.promise for loading/success/error UX.
+ */
+function readAndParseFile(file: File): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const text = reader.result?.toString() ?? '';
+        resolve(JSON.parse(text));
+      } catch (err) {
+        reject(new Error('Invalid session file (not valid JSON)'));
+      }
+    };
+    reader.onerror = () => reject(new Error('Failed to read file'));
+    reader.readAsText(file);
+  });
+}
+
+/**
+ * Counts snapshots in a parsed import payload (the export shape is a single
+ * tab-state object with a `.snapshots` array). Used for the success-toast copy.
+ */
+function countSnapshotsInPayload(payload: unknown): number {
+  if (!payload || typeof payload !== 'object') return 0;
+  const snaps = (payload as { snapshots?: unknown[] }).snapshots;
+  return Array.isArray(snaps) ? snaps.length : 0;
 }
 
 function importHandler(dispatch: (a: unknown) => void): void {
   const fileUpload = document.createElement('input');
   fileUpload.setAttribute('type', 'file');
+  fileUpload.setAttribute('accept', '.json,application/json');
 
   fileUpload.onchange = (e: Event) => {
-    const reader = new FileReader();
     const eventFiles = e.target as HTMLInputElement;
+    const file = eventFiles?.files?.[0];
+    // If the user cancelled the picker, do nothing (no toast spam).
+    if (!file) return;
 
-    if (eventFiles) {
-      reader.readAsText(eventFiles.files[0]);
-    }
+    const importPromise = readAndParseFile(file).then((parsed) => {
+      dispatch(importSnapshots(parsed));
+      return countSnapshotsInPayload(parsed);
+    });
 
-    reader.onload = () => {
-      const test = reader.result.toString();
-      return dispatch(importSnapshots(JSON.parse(test)));
-    };
+    toast.promise(
+      importPromise,
+      {
+        loading: `Importing ${file.name}...`,
+        success: (count: number) =>
+          count > 0
+            ? `Imported ${count} snapshot${count === 1 ? '' : 's'}`
+            : 'Imported session',
+        error: (err: Error) => err?.message || 'Import failed',
+      },
+      {
+        id: 'session-import',
+        style: REACTIME_TOAST_DEFAULTS.style,
+        position: REACTIME_TOAST_DEFAULTS.position,
+        success: { duration: 3000, iconTheme: REACTIME_TOAST_DEFAULTS.iconTheme },
+        error: { duration: 4500 },
+      },
+    );
   };
 
   fileUpload.click();
@@ -54,16 +133,9 @@ function ButtonsContainer(): JSX.Element {
   const handleReconnect = () => {
     dispatch(startReconnect());
     toast.success('Successfully reconnected', {
+      ...REACTIME_TOAST_DEFAULTS,
       duration: 2000,
-      position: 'top-right',
-      style: {
-        background: 'var(--bg-primary)',
-        color: 'var(--text-primary)',
-      },
-      iconTheme: {
-        primary: 'var(--color-primary)',
-        secondary: 'var(--text-primary)',
-      },
+      id: 'reconnect-success',
     });
   };
 

--- a/src/app/containers/MainContainer.tsx
+++ b/src/app/containers/MainContainer.tsx
@@ -16,9 +16,12 @@ import {
   setCurrentLocation,
   disconnected,
   endConnect,
+  startReconnect,
 } from '../slices/mainSlice';
 import { useDispatch, useSelector } from 'react-redux';
 import { MainState, RootState } from '../FrontendTypes';
+import { toast } from 'react-hot-toast';
+import { REACTIME_TOAST_DEFAULTS } from '../utils/toastConfig';
 
 /*
   This is the main container where everything in our application is rendered
@@ -31,7 +34,43 @@ function MainContainer(): JSX.Element {
 
   // Function handles when Reactime unexpectedly disconnects
   const handleDisconnect = (msg): void => {
-    if (msg === 'portDisconnect') dispatch(disconnected());
+    if (msg !== 'portDisconnect') return;
+    dispatch(disconnected());
+
+    // Surface the disconnect with an actionable toast: one-click reconnect
+    // without forcing the user to find the Reconnect button. The fixed toast id
+    // dedupes repeated disconnect messages so we don't stack toasts if Chrome
+    // fires multiple onDisconnect events in quick succession.
+    toast.error(
+      (t) => (
+        <span style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+          <span>Lost connection to the tab</span>
+          <button
+            type='button'
+            onClick={() => {
+              dispatch(startReconnect());
+              toast.dismiss(t.id);
+            }}
+            style={{
+              background: 'var(--color-primary)',
+              color: 'var(--text-primary)',
+              border: 'none',
+              borderRadius: '6px',
+              padding: '4px 10px',
+              cursor: 'pointer',
+              fontWeight: 600,
+            }}
+          >
+            Reconnect
+          </button>
+        </span>
+      ),
+      {
+        ...REACTIME_TOAST_DEFAULTS,
+        id: 'port-disconnected',
+        duration: 8000,
+      },
+    );
   };
 
   // Function to listen for a message containing snapshots from the /extension/build/background.js service worker

--- a/src/app/utils/toastConfig.ts
+++ b/src/app/utils/toastConfig.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared styling + defaults for react-hot-toast across the Reactime panel.
+ *
+ * Centralizing here so every toast matches the extension's theme tokens
+ * (dark/light aware via CSS custom properties) and picks up changes in one place.
+ * Positioning defaults to top-right to stay out of the way of the primary
+ * left-column action list and bottom-row controls.
+ */
+
+import type { ToastOptions } from 'react-hot-toast';
+
+export const REACTIME_TOAST_POSITION: ToastOptions['position'] = 'top-right';
+
+/**
+ * Base visual style used by all Reactime toasts. Uses CSS variables that
+ * ThemeProvider sets, so the toast automatically matches the active theme.
+ */
+export const REACTIME_TOAST_STYLE: ToastOptions['style'] = {
+  background: 'var(--bg-primary)',
+  color: 'var(--text-primary)',
+  border: '1px solid var(--border-primary, rgba(255,255,255,0.08))',
+};
+
+/**
+ * Icon colors for success toasts; keeps the green checkmark readable against
+ * the themed background in both light and dark modes.
+ */
+export const REACTIME_TOAST_ICON_THEME: ToastOptions['iconTheme'] = {
+  primary: 'var(--color-primary)',
+  secondary: 'var(--text-primary)',
+};
+
+/**
+ * Default options applied to every non-promise Reactime toast.
+ * Individual call sites can override any field (e.g. longer duration for
+ * errors, specific ids to dedupe repeat events).
+ */
+export const REACTIME_TOAST_DEFAULTS: ToastOptions = {
+  duration: 3000,
+  position: REACTIME_TOAST_POSITION,
+  style: REACTIME_TOAST_STYLE,
+  iconTheme: REACTIME_TOAST_ICON_THEME,
+};


### PR DESCRIPTION
<!---
☝️ Prefix your PR title with `fix:`, `feat:`, `docs:`, or other according to the Conventional Commits spec:
https://conventionalcommits.org

👉 Please make sure to follow our Contributing guidelines:
https://github.com/open-source-labs/.github/blob/main/docs/CONTRIBUTING.md
-->

## 🔗 Linked issue

 <!-- Resolves #123 -->

## Description
Adds themed, theme-aware toast notifications (via the already-installed `react-hot-toast`) for four high-signal user events in the Reactime panel. Today these actions mutate state silently  users have to re-inspect the UI to verify the action actually worked, and a port disconnect can go unnoticed until the next interaction fails. These toasts give immediate, confidence-building feedback and, in the disconnect case, a one-click path to recovery.


## Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I've followed the [Contributing guidelines](https://github.com/open-source-labs/.github/blob/main/docs/CONTRIBUTING.md)

- [x ] I've titled my PR according to the [Conventional Commits spec](https://conventionalcommits.org)
- [ ] I've linked an open issue
- [ ] I've added tests that fail without this PR but pass with it
- [ x] I've linted and tested my code
- [ ] I've updated documentation (if appropriate)
